### PR TITLE
this should be 1.x version

### DIFF
--- a/rakefile.rb
+++ b/rakefile.rb
@@ -4,7 +4,7 @@ task nokitchen: %i[version rubocop foodcritic spec]
 
 desc 'Set cookbook version.'
 task :version do
-  version = ENV['BUILD_NUMBER'] ? "0.0.#{ENV['BUILD_NUMBER']}" : '0.0.1'
+  version = ENV['BUILD_NUMBER'] ? "1.0.#{ENV['BUILD_NUMBER']}" : '1.0.0'
   IO.write('version.txt', version)
 end
 


### PR DESCRIPTION
@brentbaumann 

This cookbook has versions 1.x in Chef so I think the rakefile was incorrectly refactored in the past to 0.0.x.  This just sets it back to 1.x again for future build versions.
