### PR TITLE
java 8 for ubuntu 18.04

### DIFF
--- a/recipes/linux.rb
+++ b/recipes/linux.rb
@@ -10,7 +10,7 @@
 #
 # Wrapper cookbook for the community Java cookbook
 
-node.override['java']['jdk_version'] = '7'
+node.override['java']['jdk_version'] = '8'
 
 include_recipe 'apt'
 include_recipe 'java'


### PR DESCRIPTION
@brentbaumann 

- Ubuntu 18.04 Bionic TeamCity agents need Java 8 because Bionic doesn't have Java 7 in it's apt repositories.  Java is required for the TeamCity Agent service.